### PR TITLE
Sketch a higher-level interface in "flash_example.rs"

### DIFF
--- a/examples/flash_example.rs
+++ b/examples/flash_example.rs
@@ -1,61 +1,128 @@
 #![no_std]
 #![no_main]
 
-use bsp::entry;
-use core::cell::UnsafeCell;
-use defmt::*;
+use core::mem::{size_of, MaybeUninit};
+use defmt::{assert, *};
 use defmt_rtt as _;
-use embedded_hal::digital::v2::OutputPin;
 use embedded_time::fixed_point::FixedPoint;
 use panic_probe as _;
+use rp2040_flash::flash;
 
 // Provide an alias for our BSP so we can switch targets quickly.
 // Uncomment the BSP you included in Cargo.toml, the rest of the code does not need to change.
 use rp_pico as bsp;
 // use sparkfun_pro_micro_rp2040 as bsp;
 
+use bsp::entry;
 use bsp::hal::{
     clocks::{init_clocks_and_plls, Clock},
     pac,
-    sio::Sio,
     watchdog::Watchdog,
+    Sio,
 };
 
+const FLASH_ORIGIN: usize = 0x10000000;
+/// The erasable sector size.
+const FLASH_SECTOR_SIZE: usize = 4096;
+
+/// The payload type `T` must fit into a single flash sector.
+///
+/// If the flash-stored data is expected to survive firmware upgrades,
+/// `T` should be `repr(C)` to have a stable layout.
+///
+/// This data type itself should be flash sector aligned.
 #[repr(C, align(4096))]
-struct FlashBlock {
-    data: UnsafeCell<[u8; 4096]>,
+pub union FlashSector<T>
+where
+    T: Copy,
+{
+    data: [u8; FLASH_SECTOR_SIZE],
+    value: MaybeUninit<T>,
 }
 
-use rp2040_flash::flash;
-
-impl FlashBlock {
-    #[inline(never)]
-    fn addr(&self) -> u32 {
-        &self.data as *const _ as u32
+impl<T> FlashSector<T>
+where
+    T: Copy,
+{
+    pub const fn uninit() -> Self {
+        core::debug_assert!(
+            size_of::<T>() <= FLASH_SECTOR_SIZE,
+            "`T` must fit into a single sector size"
+        );
+        Self {
+            value: MaybeUninit::uninit(),
+        }
     }
 
-    #[inline(never)]
-    fn read(&self) -> &[u8; 4096] {
-        unsafe { &*self.data.get() }
+    const fn new(value: T) -> Self {
+        Self {
+            value: MaybeUninit::new(value),
+        }
     }
 
-    unsafe fn write_flash(&self, data: &[u8; 4096]) {
-        let addr = self.addr() - 0x10000000;
-        defmt::assert!(addr & 0xfff == 0);
+    fn mem_addr(&self) -> usize {
+        unsafe { &self.data as *const _ as usize }
+    }
+
+    pub fn read(&self) -> MaybeUninit<T> {
+        unsafe { self.value }
+    }
+
+    pub unsafe fn write(&mut self, value: T) {
+        let tmp_flash_block = FlashSector::new(value);
+        self.write_flash(&tmp_flash_block.data)
+    }
+
+    unsafe fn write_flash(&self, data: &[u8; FLASH_SECTOR_SIZE]) {
+        let flash_addr = self.mem_addr() - FLASH_ORIGIN;
+        assert!(Self::is_aligned(flash_addr, FLASH_SECTOR_SIZE));
 
         cortex_m::interrupt::free(|_cs| {
-            flash::flash_range_erase_and_program(addr, data, true);
+            flash::flash_range_erase_and_program(flash_addr as u32, data, true);
         });
+    }
+
+    const fn is_aligned(addr: usize, alignment: usize) -> bool {
+        core::assert!(Self::is_pwr_of_two(alignment));
+        addr & (alignment - 1) == 0
+    }
+
+    const fn is_pwr_of_two(n: usize) -> bool {
+        n != 0 && (n & (n - 1) == 0)
     }
 }
 
-// TODO safety analysis - this is probably not sound
-unsafe impl Sync for FlashBlock {}
+#[repr(C)]
+#[derive(Copy, Clone)]
+struct Conf {
+    validity: u8,
+    boot_counter: u32,
+}
+
+impl Conf {
+    const fn initial() -> Self {
+        Self {
+            validity: Self::VALIDITY_MARKER,
+            boot_counter: 0,
+        }
+    }
+
+    fn new(counter: u32) -> Self {
+        Self {
+            validity: Self::VALIDITY_MARKER,
+            boot_counter: counter,
+        }
+    }
+
+    fn is_valid(&self) -> bool {
+        self.validity == Self::VALIDITY_MARKER
+    }
+
+    const VALIDITY_MARKER: u8 = 0x55;
+}
 
 #[link_section = ".rodata"]
-static TEST: FlashBlock = FlashBlock {
-    data: UnsafeCell::new([0x55u8; 4096]),
-};
+static mut CONF_FLASH_SECTOR: FlashSector<Conf> = FlashSector::uninit();
 
 #[entry]
 fn main() -> ! {
@@ -65,7 +132,7 @@ fn main() -> ! {
     let mut watchdog = Watchdog::new(pac.WATCHDOG);
     let sio = Sio::new(pac.SIO);
 
-    // External high-speed crystal on the pico board is 12Mhz
+    // External high-speed crystal on the Pico board is 12 Mhz
     let external_xtal_freq_hz = 12_000_000u32;
     let clocks = init_clocks_and_plls(
         external_xtal_freq_hz,
@@ -80,11 +147,6 @@ fn main() -> ! {
     .unwrap();
 
     let mut delay = cortex_m::delay::Delay::new(core.SYST, clocks.system_clock.freq().integer());
-    // add some delay to give an attached debug probe time to parse the
-    // defmt RTT header. Reading that header might touch flash memory, which
-    // interferes with flash write operations.
-    // https://github.com/knurling-rs/defmt/pull/683
-    delay.delay_ms(10);
 
     let pins = bsp::Pins::new(
         pac.IO_BANK0,
@@ -92,6 +154,22 @@ fn main() -> ! {
         sio.gpio_bank0,
         &mut pac.RESETS,
     );
+
+    // add some delay to give an attached debug probe time to parse the
+    // defmt RTT header. Reading that header might touch flash memory, which
+    // interferes with flash write operations.
+    // https://github.com/knurling-rs/defmt/pull/683
+    delay.delay_ms(10);
+
+    let conf = {
+        let conf = unsafe { CONF_FLASH_SECTOR.read().assume_init() };
+
+        if conf.is_valid() {
+            conf
+        } else {
+            Conf::initial()
+        }
+    };
 
     let psm = pac.PSM;
 
@@ -103,22 +181,79 @@ fn main() -> ! {
     }
     psm.frce_off.modify(|_, w| w.proc1().clear_bit());
 
-    let read_data: [u8; 4096] = *TEST.read();
-    info!("Addr of flash block is {:x}", TEST.addr());
-    info!("Contents start with {=[u8]}", read_data[0..4]);
-    let mut data: [u8; 4096] = *TEST.read();
-    data[0] = data[0].wrapping_add(1);
-    core::sync::atomic::compiler_fence(core::sync::atomic::Ordering::SeqCst);
-    unsafe { TEST.write_flash(&data) };
-    core::sync::atomic::compiler_fence(core::sync::atomic::Ordering::SeqCst);
-    let read_data: [u8; 4096] = *TEST.read();
-    info!("Contents start with {=[u8]}", read_data[0..4]);
+    info!("Addr of flash block is {:x}", unsafe {
+        CONF_FLASH_SECTOR.mem_addr()
+    });
+    info!("Contents start with {=[u8]}", unsafe {
+        &CONF_FLASH_SECTOR.data[0..4]
+    });
 
-    if read_data[0] != 0x56 {
-        defmt::panic!("unexpected");
+    let new_conf = Conf::new(conf.boot_counter + 1);
+
+    core::sync::atomic::compiler_fence(core::sync::atomic::Ordering::SeqCst);
+    unsafe { CONF_FLASH_SECTOR.write(new_conf) };
+    core::sync::atomic::compiler_fence(core::sync::atomic::Ordering::SeqCst);
+
+    let updated_conf = {
+        let conf = unsafe { CONF_FLASH_SECTOR.read().assume_init() };
+        assert!(
+            conf.is_valid(),
+            "a valid configuration was written to flash, but an invalid is read back"
+        );
+        conf
+    };
+
+    info!("Contents start with {=[u8]}", unsafe {
+        &CONF_FLASH_SECTOR.data[0..4]
+    });
+
+    let led_pin = pins.led.into_push_pull_output();
+    let mut blink = blink::Blink::new(led_pin, delay);
+
+    loop {
+        blink.times(updated_conf.boot_counter).unwrap();
+        blink.pause();
     }
-
-    loop {}
 }
 
-// End of file
+mod blink {
+    use embedded_hal::{blocking::delay::DelayMs, digital::v2::OutputPin};
+
+    pub struct Blink<Pin, Delay>
+    where
+        Pin: OutputPin,
+        Delay: DelayMs<u32>,
+    {
+        pin: Pin,
+        delay: Delay,
+    }
+
+    impl<Pin, Delay> Blink<Pin, Delay>
+    where
+        Pin: OutputPin,
+        Delay: DelayMs<u32>,
+    {
+        pub fn new(pin: Pin, delay: Delay) -> Self {
+            Self { pin, delay }
+        }
+
+        pub fn times(&mut self, n: u32) -> Result<(), Pin::Error> {
+            for i in 1..=n {
+                self.pin.set_high()?;
+                self.delay.delay_ms(Self::DURATION_SHORT_MS);
+                self.pin.set_low()?;
+                if i != n {
+                    self.delay.delay_ms(Self::DURATION_SHORT_MS)
+                }
+            }
+            Ok(())
+        }
+
+        pub fn pause(&mut self) {
+            self.delay.delay_ms(Self::DURATION_LONG_MS);
+        }
+
+        const DURATION_SHORT_MS: u32 = 200;
+        const DURATION_LONG_MS: u32 = 1000;
+    }
+}


### PR DESCRIPTION
Take a look at the code around `FlashSector`, please. Does it look any good? Would you suggest any improvements, fixes, etc.?

If you find this approach good, the interface can be integrated into the library itself.

The example ended up relatively messy, because I chose to keep the original single-file layout. Can split into different files, if you find it too messy.

For reference, this is what I actually use in my project: https://github.com/werediver/escale/blob/ac1451780f03d059d7678c1e4f46be3b73387b65/escale_fw_rs/app/src/flash.rs