### PR TITLE
Sketch a higher-level interface in "flash_example.rs" (no-static approach)

### DIFF
--- a/examples/boot_counter/blink.rs
+++ b/examples/boot_counter/blink.rs
@@ -1,0 +1,39 @@
+use embedded_hal::{blocking::delay::DelayMs, digital::v2::OutputPin};
+
+const DURATION_SHORT_MS: u32 = 200;
+const DURATION_LONG_MS: u32 = 1000;
+
+pub struct Blink<Pin, Delay>
+where
+    Pin: OutputPin,
+    Delay: DelayMs<u32>,
+{
+    pin: Pin,
+    delay: Delay,
+}
+
+impl<Pin, Delay> Blink<Pin, Delay>
+where
+    Pin: OutputPin,
+    Delay: DelayMs<u32>,
+{
+    pub fn new(pin: Pin, delay: Delay) -> Self {
+        Self { pin, delay }
+    }
+
+    pub fn times(&mut self, n: u32) -> Result<(), Pin::Error> {
+        for i in 1..=n {
+            self.pin.set_high()?;
+            self.delay.delay_ms(DURATION_SHORT_MS);
+            self.pin.set_low()?;
+            if i != n {
+                self.delay.delay_ms(DURATION_SHORT_MS)
+            }
+        }
+        Ok(())
+    }
+
+    pub fn pause(&mut self) {
+        self.delay.delay_ms(DURATION_LONG_MS);
+    }
+}

--- a/examples/boot_counter/conf.rs
+++ b/examples/boot_counter/conf.rs
@@ -1,0 +1,42 @@
+const VALIDITY_MARKER: u8 = 0x55;
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct Conf {
+    validity: u8,
+    boot_counter: u32,
+}
+
+impl Default for Conf {
+    fn default() -> Self {
+        Self {
+            validity: VALIDITY_MARKER,
+            boot_counter: 0,
+        }
+    }
+}
+
+impl Conf {
+    pub fn new(counter: u32) -> Self {
+        Self {
+            validity: VALIDITY_MARKER,
+            boot_counter: counter,
+        }
+    }
+
+    pub fn is_valid(&self) -> bool {
+        self.validity == VALIDITY_MARKER
+    }
+
+    pub fn valid(self) -> Self {
+        if self.is_valid() {
+            self
+        } else {
+            Default::default()
+        }
+    }
+
+    pub fn boot_counter(&self) -> u32 {
+        self.boot_counter
+    }
+}

--- a/examples/boot_counter/flash_sector.rs
+++ b/examples/boot_counter/flash_sector.rs
@@ -1,0 +1,89 @@
+use core::{
+    mem::{size_of, MaybeUninit},
+    ptr::read_volatile,
+};
+
+use rp2040_flash::flash;
+
+/// XIP base address (see `XIP_BASE` in RP2040 datasheet).
+pub const FLASH_ORIGIN: usize = 0x10000000;
+/// RP2040 supports maximum 16 MiB of QSPI flash memory.
+pub const FLASH_END_MAX: usize = FLASH_ORIGIN + 16 * 1024 * 1024;
+/// The erasable sector size.
+const FLASH_SECTOR_SIZE: usize = 4096;
+/// The value an erased sector is filled with. This is typically 0xff.
+const FLASH_ERASED_VALUE: u8 = 0xff;
+
+/// The payload type `T` must fit into a single flash sector.
+///
+/// The payload type should be `repr(C)` to have a stable layout,
+/// because the flash-stored payload can survive firmware upgrades.
+pub union FlashSector<T>
+where
+    T: Copy,
+{
+    data: [u8; FLASH_SECTOR_SIZE],
+    value: MaybeUninit<T>,
+}
+
+impl<T> Default for FlashSector<T>
+where
+    T: Copy,
+{
+    fn default() -> Self {
+        Self {
+            data: [FLASH_ERASED_VALUE; FLASH_SECTOR_SIZE],
+        }
+    }
+}
+
+impl<T> FlashSector<T>
+where
+    T: Copy,
+{
+    pub fn new(value: T) -> Self {
+        assert!(
+            size_of::<T>() <= FLASH_SECTOR_SIZE,
+            "`T` must fit into a single sector size"
+        );
+
+        let mut instance = Self::default();
+        instance.value = MaybeUninit::new(value);
+        instance
+    }
+
+    pub unsafe fn read(mem_addr: usize) -> Self {
+        assert!(
+            size_of::<T>() <= FLASH_SECTOR_SIZE,
+            "`T` must fit into a single sector size"
+        );
+        assert!(mem_addr >= FLASH_ORIGIN);
+        assert!(mem_addr <= FLASH_END_MAX - FLASH_SECTOR_SIZE);
+        // The read address must be sector-aligned, because the write function
+        // only ever allows writing at sector-aligned addresses.
+        assert!(is_aligned(mem_addr, FLASH_SECTOR_SIZE));
+
+        let mut flash_sector = FlashSector::default();
+        flash_sector.value = unsafe { read_volatile(mem_addr as *const _) };
+        flash_sector
+    }
+
+    pub unsafe fn write(&self, mem_addr: usize) {
+        assert!(mem_addr >= FLASH_ORIGIN);
+        assert!(mem_addr <= FLASH_END_MAX - FLASH_SECTOR_SIZE);
+
+        let flash_addr = mem_addr - FLASH_ORIGIN;
+        assert!(is_aligned(flash_addr, FLASH_SECTOR_SIZE));
+
+        flash::flash_range_erase_and_program(flash_addr as u32, &self.data, true);
+    }
+
+    pub fn value(&self) -> MaybeUninit<T> {
+        unsafe { self.value }
+    }
+}
+
+const fn is_aligned(addr: usize, alignment: usize) -> bool {
+    assert!(alignment.is_power_of_two());
+    addr & (alignment - 1) == 0
+}

--- a/examples/boot_counter/main.rs
+++ b/examples/boot_counter/main.rs
@@ -1,0 +1,117 @@
+#![no_std]
+#![no_main]
+
+mod blink;
+mod conf;
+mod flash_sector;
+
+use conf::Conf;
+use flash_sector::{FlashSector, FLASH_ORIGIN};
+
+use core::mem::size_of;
+use defmt::{assert, *};
+use defmt_rtt as _;
+use panic_probe as _;
+
+// Provide an alias for our BSP so we can switch targets quickly.
+// Uncomment the BSP you included in Cargo.toml, the rest of the code does not need to change.
+use rp_pico as bsp;
+// use sparkfun_pro_micro_rp2040 as bsp;
+
+use bsp::entry;
+use bsp::hal::{
+    clocks::{init_clocks_and_plls, Clock},
+    pac,
+    watchdog::Watchdog,
+    Sio,
+};
+
+const FLASH_END: usize = FLASH_ORIGIN + 2 * 1024 * 1024;
+/// Place the configuration data at the very end of the flash memory,
+/// so that it doesn't get overwritten by normal firmware upgrades.
+const FLASH_CONF_ADDR: usize = FLASH_END - size_of::<FlashSector<Conf>>();
+
+#[entry]
+fn main() -> ! {
+    info!("Program start");
+    let mut pac = pac::Peripherals::take().unwrap();
+    let core = pac::CorePeripherals::take().unwrap();
+    let mut watchdog = Watchdog::new(pac.WATCHDOG);
+    let sio = Sio::new(pac.SIO);
+
+    // External high-speed crystal on the Pico board is 12 Mhz
+    let external_xtal_freq_hz = 12_000_000u32;
+    let clocks = init_clocks_and_plls(
+        external_xtal_freq_hz,
+        pac.XOSC,
+        pac.CLOCKS,
+        pac.PLL_SYS,
+        pac.PLL_USB,
+        &mut pac.RESETS,
+        &mut watchdog,
+    )
+    .ok()
+    .unwrap();
+
+    let mut delay = cortex_m::delay::Delay::new(core.SYST, clocks.system_clock.freq().to_Hz());
+    // add some delay to give an attached debug probe time to parse the
+    // defmt RTT header. Reading that header might touch flash memory, which
+    // interferes with flash write operations.
+    // https://github.com/knurling-rs/defmt/pull/683
+    delay.delay_ms(10);
+
+    let pins = bsp::Pins::new(
+        pac.IO_BANK0,
+        pac.PADS_BANK0,
+        sio.gpio_bank0,
+        &mut pac.RESETS,
+    );
+
+    let conf = unsafe {
+        FlashSector::<Conf>::read(FLASH_CONF_ADDR)
+            .value()
+            .assume_init()
+    }
+    .valid();
+
+    let psm = pac.PSM;
+
+    // Reset core1 so it's guaranteed to be running
+    // ROM code, waiting for the wakeup sequence
+    psm.frce_off.modify(|_, w| w.proc1().set_bit());
+    while !psm.frce_off.read().proc1().bit_is_set() {
+        cortex_m::asm::nop();
+    }
+    psm.frce_off.modify(|_, w| w.proc1().clear_bit());
+
+    info!("Addr of flash block is {:x}", FLASH_CONF_ADDR);
+
+    let new_conf = Conf::new(conf.boot_counter() + 1);
+
+    core::sync::atomic::compiler_fence(core::sync::atomic::Ordering::SeqCst);
+    unsafe { FlashSector::new(new_conf).write(FLASH_CONF_ADDR) };
+    core::sync::atomic::compiler_fence(core::sync::atomic::Ordering::SeqCst);
+
+    let updated_conf = {
+        let conf = unsafe {
+            FlashSector::<Conf>::read(FLASH_CONF_ADDR)
+                .value()
+                .assume_init()
+        };
+
+        assert!(
+            conf.is_valid(),
+            "a valid configuration was written to flash, but an invalid is read back"
+        );
+
+        conf
+    };
+
+    let led_pin = pins.led.into_push_pull_output();
+    let mut blink = blink::Blink::new(led_pin, delay);
+
+    loop {
+        blink.times(updated_conf.boot_counter()).unwrap();
+        blink.pause();
+    }
+}


### PR DESCRIPTION
A follow-up to the pull request #1.

No `static` variables are used. Instead, [core::ptr::read_volatile()](https://doc.rust-lang.org/std/ptr/fn.read_volatile.html) is used for reading.

This version is limited to single-sector operation. Arbitrary payload length can be implemented as shown in [werediver/escale/escale_fw_rs/app/src/flash.rs](https://github.com/werediver/escale/blob/96d66d79f5e7f4577d961787db47db83073bb9b7/escale_fw_rs/app/src/flash.rs) (requires `generic_const_exprs` feature).