### PR TITLE
Add support for reading SPI flash JEDEC ID and unique ID

### DIFF
--- a/examples/flash_example.rs
+++ b/examples/flash_example.rs
@@ -108,17 +108,10 @@ fn main() -> ! {
     }
     psm.frce_off.modify(|_, w| w.proc1().clear_bit());
 
-    let jedec_id: u32 = unsafe {
-        cortex_m::interrupt::free(|_cs| {
-            flash::flash_jedec_id(true)
-        })
-    };
+    let jedec_id: u32 = unsafe { cortex_m::interrupt::free(|_cs| flash::flash_jedec_id(true)) };
     info!("JEDEC ID {:x}", jedec_id);
-    let unique_id: u64 = unsafe {
-        cortex_m::interrupt::free(|_cs| {
-            flash::flash_unique_id(true)
-        })
-    };
+    let mut unique_id = [0u8; 8];
+    unsafe { cortex_m::interrupt::free(|_cs| flash::flash_unique_id(&mut unique_id, true)) };
     info!("Unique ID {:x}", unique_id);
 
     let read_data: [u8; 4096] = *TEST.read();

--- a/examples/flash_example.rs
+++ b/examples/flash_example.rs
@@ -108,6 +108,19 @@ fn main() -> ! {
     }
     psm.frce_off.modify(|_, w| w.proc1().clear_bit());
 
+    let jedec_id: u32 = unsafe {
+        cortex_m::interrupt::free(|_cs| {
+            flash::flash_jedec_id(true)
+        })
+    };
+    info!("JEDEC ID {:x}", jedec_id);
+    let unique_id: u64 = unsafe {
+        cortex_m::interrupt::free(|_cs| {
+            flash::flash_unique_id(true)
+        })
+    };
+    info!("Unique ID {:x}", unique_id);
+
     let read_data: [u8; 4096] = *TEST.read();
     info!("Addr of flash block is {:x}", TEST.addr());
     info!("Contents start with {=[u8]}", read_data[0..4]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,4 +238,189 @@ pub mod flash {
             clobber_abi("C"),
         );
     }
+
+    /// Return SPI flash unique ID
+    ///
+    /// Most SPI flash chips accept this command (the Winbond parts
+    /// commonly seen on RP2040 devboards certainly do).
+    ///
+    /// The returned bytes are relatively predictable and should be
+    /// salted and hashed before use if that is an issue (e.g. for MAC
+    /// addresses).
+    ///
+    /// # Safety
+    ///
+    /// Nothing must access flash while this is running.
+    /// Usually this means:
+    ///   - interrupts must be disabled
+    ///   - 2nd core must be running code from RAM or ROM with interrupts disabled
+    ///   - DMA must not access flash memory
+    pub unsafe fn flash_unique_id(use_boot2: bool) -> u64 {
+        let mut boot2 = [0u32; 256 / 4];
+        let ptrs = if use_boot2 {
+            rom_data::memcpy44(&mut boot2 as *mut _, 0x10000000 as *const _, 256);
+            flash_function_pointers_with_boot2(true, true, &boot2)
+        } else {
+            flash_function_pointers(false, false)
+        };
+        let mut id = [0u8; 8];
+        let p = id.as_mut_ptr();
+
+        // 4B - read unique ID, +0x400 -> 4 dummy bytes
+        read_flash_inner(0x44B, 8, p, &ptrs as *const FlashFunctionPointers);
+        u64::from_be_bytes(id)
+    }
+
+    /// Return SPI flash JEDEC ID
+    ///
+    /// This is the three-byte manufacturer-and-model identifier
+    /// commonly used to check before using manufacturer-specific SPI
+    /// flash features, e.g. 0xEF7015 for Winbond W25Q16JV.
+    ///
+    /// # Safety
+    ///
+    /// Nothing must access flash while this is running.
+    /// Usually this means:
+    ///   - interrupts must be disabled
+    ///   - 2nd core must be running code from RAM or ROM with interrupts disabled
+    ///   - DMA must not access flash memory
+    pub unsafe fn flash_jedec_id(use_boot2: bool) -> u32 {
+        let mut boot2 = [0u32; 256 / 4];
+        let ptrs = if use_boot2 {
+            rom_data::memcpy44(&mut boot2 as *mut _, 0x10000000 as *const _, 256);
+            flash_function_pointers_with_boot2(false, false, &boot2)
+        } else {
+            flash_function_pointers(false, false)
+        };
+        let mut id = [0u8; 4];
+        let p = id.as_mut_ptr().add(1);
+
+        // 9F - read JEDEC ID
+        read_flash_inner(0x9F, 3, p, &ptrs as *const FlashFunctionPointers);
+        u32::from_be_bytes(id)
+    }
+
+    /// Issue a generic SPI flash read command
+    ///
+    /// # Arguments
+    ///
+    /// * `cmd_skip` - SPI flash command (bits 0-7) plus dummy-byte count (bits 15-8)
+    /// * `len` - Transfer length *excluding* any dummy bytes
+    /// * `data` - Result buffer, must be at least `len` bytes long
+    /// * `ptrs` - Flash function pointers as per
+    #[inline(never)]
+    #[link_section = ".data.ram_func"]
+    unsafe fn read_flash_inner(
+        cmd_skip: u16,
+        len: u32,
+        data: *mut u8,
+        ptrs: *const FlashFunctionPointers,
+    ) {
+        core::arch::asm!(
+            "mov r8, r0", // cmd+skip
+            "mov r9, r1", // len
+            "mov r10, r2", // data
+            "mov r6, r3", // ptrs
+
+            "ldr r4, [r6, #0]",
+            "blx r4", // connect_internal_flash()
+
+            "ldr r4, [r6, #4]",
+            "blx r4", // flash_exit_xip()
+
+            "movs r4, #0x18",
+            "lsls r4, r4, #24", // 0x18000000, SSI, RP2040 datasheet 4.10.13
+
+            // disable, write 0 to SSIENR
+            "movs r0, #0",
+            "str r0, [r4, #8]", // SSIENR
+
+            // write ctrlr0
+            "movs r0, #0x3",
+            "lsls r0, r0, #8", // TMOD=0x300
+            "ldr r1, [r4, #0]", // CTRLR0
+            "orrs r1, r0",
+            "str r1, [r4, #0]",
+
+            // rx, so write ctrlr1 with len-1
+            "mov r0, r9",
+            "subs r0, #1",
+            "mov r1, r8", // cmd+skip
+            "asrs r1, #8", // skip
+            "add r0, r0, r1", // total xfer
+            "str r0, [r4, #0x04]", // CTRLR1
+
+            // enable, write 1 to ssienr
+            "movs r0, #1",
+            "str r0, [r4, #8]", // SSIENR
+
+            // write cmd to dr
+            "mov r2, r4",
+            "adds r2, 0x60", // &DR
+            "mov r0, r8",
+            "str r0, [r2]", // DR
+
+            // Skip any dummy cycles
+            "mov r1, r8", // cmd+skip
+            "asrs r1, #8", // skip
+            "beq 9f",
+            "4:",
+            "ldr r0, [r4, #0x28]", // SR
+            "movs r2, #0x8",
+            "tst r0, r2",
+            "beq 4b",
+            "mov r2, r4",
+            "adds r2, 0x60", // &DR
+            "ldrb r0, [r2]", // DR
+            "subs r1, #1",
+            "bne 4b",
+
+            // Read RX fifo
+            "9:",
+            "mov r1, r9", // len
+            "mov r5, r10", // data
+
+            "2:",
+            "ldr r0, [r4, #0x28]", // SR
+            "movs r2, #0x8",
+            "tst r0, r2", // SR.RFNE
+            "beq 2b",
+
+            "mov r2, r4",
+            "adds r2, 0x60", // &DR
+            "ldr r0, [r2]", // DR
+            "strb r0, [r5]",
+            "adds r5, #1",
+            "subs r1, #1",
+            "bne 2b",
+
+            // Disable, write 0 to ssienr
+            "movs r0, #0",
+            "str r0, [r4, #8]", // SSIENR
+
+            // Write 0 to CTRLR1 (returning to its default value)
+            //
+            // flash_enter_cmd_xip does NOT do this, and everything goes
+            // wrong unless we do it here
+            "str r0, [r4, #4]", // CTRLR1
+
+            "ldr r4, [r6, #20]",
+            "blx r4", // flash_enter_cmd_xip();
+
+            in("r0") cmd_skip,
+            in("r1") len,
+            in("r2") data,
+            in("r3") ptrs,
+            out("r4") _,
+            // Registers r8-r10 are used to store values
+            // from r0-r2 in registers not clobbered by
+            // function calls.
+            // The values can't be passed in using r8-r10 directly
+            // due to https://github.com/rust-lang/rust/issues/99071
+            out("r8") _,
+            out("r9") _,
+            out("r10") _,
+            clobber_abi("C"),
+        );
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -239,10 +239,25 @@ pub mod flash {
         );
     }
 
+    #[repr(C)]
+    struct FlashCommand {
+        cmd_addr: *const u8,
+        cmd_addr_len: u32,
+        dummy_len: u32,
+        data: *mut u8,
+        data_len: u32,
+    }
+
     /// Return SPI flash unique ID
     ///
-    /// Most SPI flash chips accept this command (the Winbond parts
-    /// commonly seen on RP2040 devboards certainly do).
+    /// Not all SPI flashes implement this command, so check the JEDEC
+    /// ID before relying on it. The Winbond parts commonly seen on
+    /// RP2040 devboards (JEDEC=0xEF7015) support an 8-byte unique ID;
+    /// https://forums.raspberrypi.com/viewtopic.php?t=331949 suggests
+    /// that LCSC (Zetta) parts have a 16-byte unique ID (which is
+    /// *not* unique in just its first 8 bytes),
+    /// JEDEC=0xBA6015. Macronix and Spansion parts do not have a
+    /// unique ID.
     ///
     /// The returned bytes are relatively predictable and should be
     /// salted and hashed before use if that is an issue (e.g. for MAC
@@ -255,20 +270,17 @@ pub mod flash {
     ///   - interrupts must be disabled
     ///   - 2nd core must be running code from RAM or ROM with interrupts disabled
     ///   - DMA must not access flash memory
-    pub unsafe fn flash_unique_id(use_boot2: bool) -> u64 {
+    pub unsafe fn flash_unique_id(out: &mut [u8], use_boot2: bool) {
         let mut boot2 = [0u32; 256 / 4];
         let ptrs = if use_boot2 {
             rom_data::memcpy44(&mut boot2 as *mut _, 0x10000000 as *const _, 256);
-            flash_function_pointers_with_boot2(true, true, &boot2)
+            flash_function_pointers_with_boot2(false, false, &boot2)
         } else {
             flash_function_pointers(false, false)
         };
-        let mut id = [0u8; 8];
-        let p = id.as_mut_ptr();
-
-        // 4B - read unique ID, +0x400 -> 4 dummy bytes
-        read_flash_inner(0x44B, 8, p, &ptrs as *const FlashFunctionPointers);
-        u64::from_be_bytes(id)
+        // 4B - read unique ID
+        let cmd = [0x4B];
+        read_flash(&cmd[..], 4, out, &ptrs as *const FlashFunctionPointers);
     }
 
     /// Return SPI flash JEDEC ID
@@ -293,104 +305,125 @@ pub mod flash {
             flash_function_pointers(false, false)
         };
         let mut id = [0u8; 4];
-        let p = id.as_mut_ptr().add(1);
-
         // 9F - read JEDEC ID
-        read_flash_inner(0x9F, 3, p, &ptrs as *const FlashFunctionPointers);
+        let cmd = [0x9F];
+        read_flash(
+            &cmd[..],
+            0,
+            &mut id[1..4],
+            &ptrs as *const FlashFunctionPointers,
+        );
         u32::from_be_bytes(id)
+    }
+
+    unsafe fn read_flash(
+        cmd_addr: &[u8],
+        dummy_len: u32,
+        out: &mut [u8],
+        ptrs: *const FlashFunctionPointers,
+    ) {
+        read_flash_inner(
+            FlashCommand {
+                cmd_addr: cmd_addr.as_ptr(),
+                cmd_addr_len: cmd_addr.len() as u32,
+                dummy_len,
+                data: out.as_mut_ptr(),
+                data_len: out.len() as u32,
+            },
+            ptrs,
+        );
     }
 
     /// Issue a generic SPI flash read command
     ///
     /// # Arguments
     ///
-    /// * `cmd_skip` - SPI flash command (bits 0-7) plus dummy-byte count (bits 15-8)
-    /// * `len` - Transfer length *excluding* any dummy bytes
-    /// * `data` - Result buffer, must be at least `len` bytes long
-    /// * `ptrs` - Flash function pointers as per
+    /// * `cmd` - `FlashCommand` structure
+    /// * `ptrs` - Flash function pointers as per `write_flash_inner`
     #[inline(never)]
     #[link_section = ".data.ram_func"]
-    unsafe fn read_flash_inner(
-        cmd_skip: u16,
-        len: u32,
-        data: *mut u8,
-        ptrs: *const FlashFunctionPointers,
-    ) {
+    unsafe fn read_flash_inner(cmd: FlashCommand, ptrs: *const FlashFunctionPointers) {
         core::arch::asm!(
-            "mov r8, r0", // cmd+skip
-            "mov r9, r1", // len
-            "mov r10, r2", // data
-            "mov r6, r3", // ptrs
+            "mov r10, r0", // cmd
+            "mov r5, r1", // ptrs
 
-            "ldr r4, [r6, #0]",
+            "ldr r4, [r5, #0]",
             "blx r4", // connect_internal_flash()
 
-            "ldr r4, [r6, #4]",
+            "ldr r4, [r5, #4]",
             "blx r4", // flash_exit_xip()
+
+            "mov r7, r10", // cmd
 
             "movs r4, #0x18",
             "lsls r4, r4, #24", // 0x18000000, SSI, RP2040 datasheet 4.10.13
 
-            // disable, write 0 to SSIENR
+            // Disable, write 0 to SSIENR
             "movs r0, #0",
             "str r0, [r4, #8]", // SSIENR
 
-            // write ctrlr0
+            // Write ctrlr0
             "movs r0, #0x3",
             "lsls r0, r0, #8", // TMOD=0x300
             "ldr r1, [r4, #0]", // CTRLR0
             "orrs r1, r0",
             "str r1, [r4, #0]",
 
-            // rx, so write ctrlr1 with len-1
-            "mov r0, r9",
+            // Write ctrlr1 with len-1
+            "ldr r0, [r7, #8]", // dummy_len
+            "ldr r1, [r7, #16]", // data_len
+            "add r0, r1",
             "subs r0, #1",
-            "mov r1, r8", // cmd+skip
-            "asrs r1, #8", // skip
-            "add r0, r0, r1", // total xfer
             "str r0, [r4, #0x04]", // CTRLR1
 
-            // enable, write 1 to ssienr
+            // Enable, write 1 to ssienr
             "movs r0, #1",
             "str r0, [r4, #8]", // SSIENR
 
-            // write cmd to dr
+            // Write cmd/addr phase to DR
             "mov r2, r4",
             "adds r2, 0x60", // &DR
-            "mov r0, r8",
-            "str r0, [r2]", // DR
+            "ldr r0, [r7, #0]", // cmd_addr
+            "ldr r1, [r7, #4]", // cmd_addr_len
+            "10:",
+            "ldrb r3, [r0]",
+            "strb r3, [r2]", // DR
+            "adds r0, #1",
+            "subs r1, #1",
+            "bne 10b",
 
             // Skip any dummy cycles
-            "mov r1, r8", // cmd+skip
-            "asrs r1, #8", // skip
+            "ldr r1, [r7, #8]", // dummy_len
+            "cmp r1, #0",
             "beq 9f",
             "4:",
-            "ldr r0, [r4, #0x28]", // SR
+            "ldr r3, [r4, #0x28]", // SR
             "movs r2, #0x8",
-            "tst r0, r2",
+            "tst r3, r2", // SR.RFNE
             "beq 4b",
+
             "mov r2, r4",
             "adds r2, 0x60", // &DR
-            "ldrb r0, [r2]", // DR
+            "ldrb r3, [r2]", // DR
             "subs r1, #1",
             "bne 4b",
 
             // Read RX fifo
             "9:",
-            "mov r1, r9", // len
-            "mov r5, r10", // data
+            "ldr r0, [r7, #12]", // data
+            "ldr r1, [r7, #16]", // data_len
 
             "2:",
-            "ldr r0, [r4, #0x28]", // SR
+            "ldr r3, [r4, #0x28]", // SR
             "movs r2, #0x8",
-            "tst r0, r2", // SR.RFNE
+            "tst r3, r2", // SR.RFNE
             "beq 2b",
 
             "mov r2, r4",
             "adds r2, 0x60", // &DR
-            "ldr r0, [r2]", // DR
-            "strb r0, [r5]",
-            "adds r5, #1",
+            "ldrb r3, [r2]", // DR
+            "strb r3, [r0]",
+            "adds r0, #1",
             "subs r1, #1",
             "bne 2b",
 
@@ -404,13 +437,13 @@ pub mod flash {
             // wrong unless we do it here
             "str r0, [r4, #4]", // CTRLR1
 
-            "ldr r4, [r6, #20]",
+            "ldr r4, [r5, #20]",
             "blx r4", // flash_enter_cmd_xip();
 
-            in("r0") cmd_skip,
-            in("r1") len,
-            in("r2") data,
-            in("r3") ptrs,
+            in("r0") &cmd as *const FlashCommand,
+            in("r1") ptrs,
+            out("r2") _,
+            out("r3") _,
             out("r4") _,
             // Registers r8-r10 are used to store values
             // from r0-r2 in registers not clobbered by


### PR DESCRIPTION
Hi, I needed to get hold of the SPI flash unique ID on my RP2040 board (in fact it's a W5500-EVB-Pico) and your excellent crate provided 95% of what I needed. This PR adds the remaining 5%.

The resetting of SSI.CTRLR1 to zero at the end is _absolutely_ essential to avoid mysterious crashes; that took a _long_ time to work out!

Tested on W5500-EVB-Pico only, but should be compatible with basically all RP2040 boards.