### PR TITLE
Update rp2040-hal to 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://github.com/jannic/rp2040-flash/"
 readme = "README.md"
 
 [dependencies]
-rp2040-hal = { version = "0.9.0", default-features = false }
+rp2040-hal = { version = "0.10.0", default-features = false }
 
 [dev-dependencies]
 cortex-m = "0.7.7"
@@ -21,4 +21,4 @@ defmt-rtt = "0.4.0"
 embedded-hal = "0.2.7"
 embedded-time = "0.12.1"
 panic-probe = "0.3.0"
-rp-pico = "0.8.0"
+rp-pico = "0.9"


### PR DESCRIPTION
Also update rp-pico as you can't mix (transitive) rp2040-hal versions or you get duplicate-symbol errors from the linker.

Much as I sometimes get annoyed by the constant conveyor-belt of Rust crate updates, lots of other RP2040 crates now use rp2040-hal 0.10, and so I needed a version of rp2040-flash that was consistent with them. No actual code changes in rp2040-flash were needed.